### PR TITLE
add Bearer Token Authorization mode using JWT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,23 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/config/AppSecurityConfig.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/config/AppSecurityConfig.java
@@ -1,5 +1,7 @@
 package fr.algofi.hnn.springsecuritytuto.config;
 
+import fr.algofi.hnn.springsecuritytuto.filter.JWTGeneratorFilter;
+import fr.algofi.hnn.springsecuritytuto.filter.JWTValidatorFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -8,11 +10,13 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
 import org.springframework.security.web.authentication.password.HaveIBeenPwnedRestApiPasswordChecker;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -32,6 +36,9 @@ public class AppSecurityConfig {
 //        http.sessionManagement(smc -> smc.invalidSessionUrl("/invalidsession").maximumSessions(1).maxSessionsPreventsLogin(true));
 
         http.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(smc -> smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JWTValidatorFilter(), BasicAuthenticationFilter.class)
+                .addFilterAfter(new JWTGeneratorFilter(), BasicAuthenticationFilter.class)
                 .authorizeHttpRequests((requests) ->
                         requests.requestMatchers(HttpMethod.POST, "/users").access(
                                     new WebExpressionAuthorizationManager("hasAuthority('WRITE_USER') && hasRole('ADMIN')"))

--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/JWTGeneratorFilter.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/JWTGeneratorFilter.java
@@ -1,0 +1,48 @@
+package fr.algofi.hnn.springsecuritytuto.filter;
+
+import fr.algofi.hnn.springsecuritytuto.util.AppConstant;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+public class JWTGeneratorFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            SecretKey secretKey = Keys.hmacShaKeyFor(AppConstant.JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+            String jwt = Jwts.builder().issuer("Spring-Secu-Tuto").subject("JWT")
+                    .claim("username", authentication.getName())
+                    .claim("authorities", authentication.getAuthorities()
+                            .stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(",")))
+                    .issuedAt(new Date())
+                    .expiration(new Date((new Date()).getTime() + 3600000))
+                    .signWith(secretKey).compact();
+            response.setHeader(AppConstant.AUTHORIZATION_HEADER, jwt);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String jwt = request.getHeader(AppConstant.AUTHORIZATION_HEADER);
+        if (jwt != null && jwt.contains("Bearer")) {
+            return true;
+        }
+        return super.shouldNotFilter(request);
+    }
+}

--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/JWTValidatorFilter.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/JWTValidatorFilter.java
@@ -1,0 +1,52 @@
+package fr.algofi.hnn.springsecuritytuto.filter;
+
+import fr.algofi.hnn.springsecuritytuto.util.AppConstant;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class JWTValidatorFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String jwt = request.getHeader(AppConstant.AUTHORIZATION_HEADER);
+        if (jwt != null && !jwt.contains("Basic ") && jwt.contains("Bearer")) {
+            try {
+                String token = jwt.split(" ")[1];
+                SecretKey secretKey = Keys.hmacShaKeyFor(AppConstant.JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+                Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+                String username = claims.get("username", String.class);
+                String authorities = claims.get("authorities", String.class);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(username, null,
+                        AuthorityUtils.commaSeparatedStringToAuthorityList(authorities));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                throw new BadCredentialsException(e.getMessage());
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String jwt = request.getHeader(AppConstant.AUTHORIZATION_HEADER);
+        if (jwt == null || (jwt != null && jwt.contains("Basic"))) {
+            return true;
+        }
+        return super.shouldNotFilter(request);
+    }
+}

--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/util/AppConstant.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/util/AppConstant.java
@@ -1,0 +1,6 @@
+package fr.algofi.hnn.springsecuritytuto.util;
+
+public final class AppConstant {
+    public static final String JWT_SECRET = "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+}


### PR DESCRIPTION
Add filters for the creation and validation of JWT tokens, so that we can use the Bearer Token Authorization mode