### PR TITLE
Correction: use real Principal object in the place of String (as username)

### DIFF
--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/config/AppSecurityConfig.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/config/AppSecurityConfig.java
@@ -10,7 +10,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -36,7 +35,7 @@ public class AppSecurityConfig {
 //        http.sessionManagement(smc -> smc.invalidSessionUrl("/invalidsession").maximumSessions(1).maxSessionsPreventsLogin(true));
 
         http.csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(smc -> smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .sessionManagement(smc -> smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS))     // using this make test by browser fail
                 .addFilterBefore(new JWTValidatorFilter(), BasicAuthenticationFilter.class)
                 .addFilterAfter(new JWTGeneratorFilter(), BasicAuthenticationFilter.class)
                 .authorizeHttpRequests((requests) ->

--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/JWTValidatorFilter.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/JWTValidatorFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import javax.crypto.SecretKey;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 
 public class JWTValidatorFilter extends OncePerRequestFilter {
     @Override
@@ -31,7 +32,8 @@ public class JWTValidatorFilter extends OncePerRequestFilter {
                 Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
                 String username = claims.get("username", String.class);
                 String authorities = claims.get("authorities", String.class);
-                Authentication authentication = new UsernamePasswordAuthenticationToken(username, null,
+                Principal principal = new SimplePrincipal(username);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null,
                         AuthorityUtils.commaSeparatedStringToAuthorityList(authorities));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception e) {
@@ -44,7 +46,7 @@ public class JWTValidatorFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String jwt = request.getHeader(AppConstant.AUTHORIZATION_HEADER);
-        if (jwt == null || (jwt != null && jwt.contains("Basic"))) {
+        if (jwt == null || jwt.contains("Basic")) {
             return true;
         }
         return super.shouldNotFilter(request);

--- a/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/SimplePrincipal.java
+++ b/src/main/java/fr/algofi/hnn/springsecuritytuto/filter/SimplePrincipal.java
@@ -1,0 +1,18 @@
+package fr.algofi.hnn.springsecuritytuto.filter;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.security.Principal;
+
+@Getter
+@AllArgsConstructor
+public class SimplePrincipal implements Principal {
+
+    private String username;
+
+    @Override
+    public String getName() {
+        return this.username;
+    }
+}


### PR DESCRIPTION
Use real Principal object (create SimplePrincipal class) in the place of String (username) because in my code there are some conditions as 'auth.principal.username' (Exception if not). Remove Stateless session because it causes tests in browser fail.